### PR TITLE
remove decode, undefined for py3 strings

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -10,7 +10,7 @@ BASE = '/%s' % app.config['REPO_NAME']
 @app.route('/')
 def home():
     with open('talk.md', 'r') as f:
-        template = Template(f.read().decode('utf-8'))
+        template = Template(f.read())
         markdown = template.render(base=BASE)
         js_file = 'talk.js'
         if os.path.isfile(js_file):


### PR DESCRIPTION
In Python3 read() converts text file to unicode, and decode is not defined for
string objects

In Python2 decode is not required because the template engine handles it